### PR TITLE
Quick Fix for uploading one to many

### DIFF
--- a/src/DropZone/DropZone.xml
+++ b/src/DropZone/DropZone.xml
@@ -13,7 +13,7 @@ iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAN30lEQVR42u1Ze3AV1Rn/zu5935uE8EYC
 			<category>Data</category>
 			<description></description>
 		</property>
-		<property key="nameattr" type="attribute" required="true">
+		<property key="nameattr" type="attribute" required="true" entityProperty="imageentity">
 			<caption>Name attribute</caption>
 			<category>Data</category>
 			<description>Attribute for name of the file, normally 'name'</description> 


### PR DESCRIPTION
When Dropzone widget is not placed inside the FileDocument data view, but placed inside parent context, the name attribute could not be selected.

Not sure why you would like the select the name anyway, as the Name attribute of system.FileDocument is not likely to change.