### PR TITLE
Fix loading css in linux environments

### DIFF
--- a/src/DropZone/widget/DropZone.js
+++ b/src/DropZone/widget/DropZone.js
@@ -3,7 +3,7 @@
 
 */
 
-mxui.dom.addCss('widgets/Dropzone/widget/css/dropzone.css');
+mxui.dom.addCss('widgets/DropZone/widget/css/dropzone.css');
 define([
     "dojo/_base/declare",
     "mxui/widget/_WidgetBase",


### PR DESCRIPTION
see https://mxforum.mendix.com/questions/20082/CSS-for-Dropzone-Widget-Not-Found-when-app-deployed-to-cloud

Linux (which is used in the Mendix cloud) is case sensitive, meaning
that paths must match exactly. Windows ignores this, which is why this
didn't turn up earlier.