### PR TITLE
Change eventlistner to act on touchstart

### DIFF
--- a/src/DropZone/widget/lib/dropzone.js
+++ b/src/DropZone/widget/lib/dropzone.js
@@ -686,7 +686,19 @@
                   _this.hiddenFileInput.click();
                 }
                 return true;
-              }
+              },
+              /*
+              // scb fix for iOS8
+              // it was supposed to be fixed in https://github.com/enyo/dropzone/issues/935 release 4.1.1
+              // yet in 4.3.0 it doesn't work anymore so I added the touchstart and stopPropagation
+              */
+              "touchstart": function(evt) {
+                evt.stopPropagation();
+                if ((clickableElement !== _this.element) || (evt.target === _this.element || Dropzone.elementInside(evt.target, _this.element.querySelector(".dz-message")))) {
+                  _this.hiddenFileInput.click();
+                }
+                return true;
+              } 
             }
           });
         };


### PR DESCRIPTION
Fix for iOS8 (iPhone 5/6)

In the old situation a double tap on the dropzone was required to open the file explorer on iOS8 devices (the first one was probably interpreted as an hover). 

This commit adds the touchstart, now a single tap on the dropzone in iOS8 should open the file explorer.